### PR TITLE
reduced number of calls to ingredient_slicer, added code to keep all …

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "python.analysis.typeCheckingMode": "basic"
+}

--- a/main.py
+++ b/main.py
@@ -1,14 +1,19 @@
 import argparse
 import os
+import re
+import json
 import pandas as pd
+import numpy as np
 
-from preprocessing._utils import get_usda_urls
-from preprocessing._utils import fillna_and_define_dtype
+from preprocessing._utils import get_usda_urls, dict_to_json, fillna_and_define_dtype, postprocess_stacked_df, fillna_and_set_dtypes
 
 from preprocessing.process_foundation import process_foundation
 from preprocessing.process_srlegacy import process_srlegacy
 from preprocessing.process_branded import process_branded
 
+# ---------------------------------------------------------------------
+# ---- Parse command-line arguments ----
+# ---------------------------------------------------------------------
 
 # Parse command-line arguments
 parser = argparse.ArgumentParser(description='download and process USDA Food Data Central datasets.')
@@ -17,40 +22,47 @@ parser.add_argument('--filename', default='usda_food_nutrition_data.parquet', he
 parser.add_argument('--keep_files', action='store_true', help='keep raw/indv files post-processing (default: delete raw/indv files)')
 args = parser.parse_args()
 
-
 # Check filename and extension
 filename = args.filename
 file_ext = filename.split('.')[-1] if '.' in filename else None
 filename = filename if file_ext else f"{filename}.csv"
-
 
 # Check keep_files flag
 keep_files = args.keep_files
 if keep_files:
     print(f"\n'keep_files' flag specified:\n> Raw and individual files will be kept after processing.")
 
+# ---------------------------------------------------------------------
+# ---- Setup raw and output directories ----
+# ---------------------------------------------------------------------
 
 # Define directories and ensure they exist (raw_dir existence will be checked in individual processing files)
 OUTPUT_DIR = args.output_dir
 RAW_DIR = os.path.join(OUTPUT_DIR, 'FoodData_Central_raw')
 print(f'\nInitializing processing of USDA FDC data. Output directory set to:\n> {OUTPUT_DIR}\n')
 
-
 if not os.path.exists(OUTPUT_DIR):
     os.makedirs(OUTPUT_DIR)
     print(f'Directory created:\n> {OUTPUT_DIR}\n')
 
+# ---------------------------------------------------------------------
+# ---- Process USDA datasets ----
+# ---------------------------------------------------------------------
 
 # Gather urls and send them out to appropriate processing scripts
 usda_urls = get_usda_urls()
 
 foundation_urls = [url for url in usda_urls if 'foundation' in url or 'FoodData_Central_csv' in url]
-srlegacy_url = [url for url in usda_urls if 'sr_legacy' in url][0]
-branded_url = [url for url in usda_urls if 'branded' in url][0]
+srlegacy_url    = [url for url in usda_urls if 'sr_legacy' in url][0]
+branded_url     = [url for url in usda_urls if 'branded' in url][0]
 
 process_foundation(foundation_urls, OUTPUT_DIR, RAW_DIR, keep_files)
 process_srlegacy(srlegacy_url, OUTPUT_DIR, RAW_DIR, keep_files)
 process_branded(branded_url, OUTPUT_DIR, RAW_DIR, keep_files)
+
+# ---------------------------------------------------------------------
+# ---- Postprocess processed USDA datasets ----
+# ---------------------------------------------------------------------
 
 print(f'Initializing stacking of individually processed data:')
 for root, dirs, files in os.walk(OUTPUT_DIR):
@@ -58,35 +70,23 @@ for root, dirs, files in os.walk(OUTPUT_DIR):
         if '.parquet' in file:
             print(f'> {file}')
 
-
 # Stack processed data, reorder columns, and save csv
 stacked_data = pd.concat([
     pd.read_parquet(os.path.join(OUTPUT_DIR, 'processed_foundation.parquet')),
     pd.read_parquet(os.path.join(OUTPUT_DIR, 'processed_srlegacy.parquet')),
     pd.read_parquet(os.path.join(OUTPUT_DIR, 'processed_branded.parquet'))
 ])
-stacked_data.reset_index(drop=True, inplace=True)
 
-stacked_data = stacked_data[[
-                        'fdc_id', 'usda_data_source', 'data_type', 'category', 'brand_owner', 'brand_name', 'food_description', 'ingredients', 
-                        'portion_amount', 'portion_unit', 'portion_modifier', 'std_portion_amount', 'std_portion_unit', 'portion_gram_weight', 
-                        'portion_energy', 'energy', 'carbohydrate_by_difference', 'protein', 'total_lipid_fat', 'fiber_total_dietary', 'sugars_total', 
-                        'calcium_ca', 'iron_fe', 'vitamin_c_total_ascorbic_acid', 'vitamin_a_rae', 'vitamin_e_alphatocopherol', 
-                        'sodium_na', 'cholesterol', 'fatty_acids_total_saturated', 'fatty_acids_total_trans', 'fatty_acids_total_monounsaturated', 
-                        'fatty_acids_total_polyunsaturated', 'vitamin_k_phylloquinone', 'thiamin', 'riboflavin', 'niacin', 'vitamin_b6', 'folate_total', 
-                        'vitamin_b12', 'vitamin_d3_cholecalciferol', 'vitamin_d2_ergocalciferol', 'pantothenic_acid', 'phosphorus_p', 'magnesium_mg', 
-                        'potassium_k', 'zinc_zn', 'copper_cu', 'manganese_mn', 'selenium_se', 'carotene_beta', 'retinol', 'vitamin_k_dihydrophylloquinone', 
-                        'vitamin_k_menaquinone4', 'tryptophan', 'threonine', 'methionine', 'phenylalanine', 'tyrosine', 'valine', 'arginine', 'histidine', 
-                        'isoleucine', 'leucine', 'lysine', 'cystine', 'alanine', 'glutamic_acid', 'glycine', 'proline', 'serine', 'sucrose', 'glucose', 
-                        'maltose', 'fructose', 'lactose', 'galactose', 'choline_total', 'betaine'
-                    ]]
+# apply some post-processing 
+# (select columns, fillna, set dtypes, fill in missing food_common_name and food_common_category values by food_description groups)
+stacked_data = postprocess_stacked_df(stacked_data)
 
-for col in stacked_data.columns.tolist():
-    fillna_and_define_dtype(stacked_data, col)
+# ---------------------------------------------------------------------
+# ---- Save final output data and cleanup directories ----
+# ---------------------------------------------------------------------
 
 stacked_data.to_csv(os.path.join(OUTPUT_DIR, filename), index=False)
-
-
+# stacked_data.to_parquet(os.path.join(OUTPUT_DIR, "usda_food_nutrition_data2.parquet"), index=False)
 
 # Delete raw dir/individual processed files if keep_files flag is not specified
 for root, dirs, files in os.walk(OUTPUT_DIR):
@@ -106,4 +106,3 @@ for root, dirs, files in os.walk(OUTPUT_DIR):
 
 
 print(f"\nProcessing of USDA FDC data is complete. The processed data file ('{filename}') is now available in:\n> {OUTPUT_DIR}\n")
-

--- a/preprocessing/_constants.py
+++ b/preprocessing/_constants.py
@@ -1,0 +1,38 @@
+import re
+
+# IMPS Meat standard series names from USDA / AMS standards
+# Source: https://www.ams.usda.gov/grades-standards/imps
+    # General Requirements (GR)
+    # Quality Assurance Provisions (QAP)
+    # Fresh Beef Series 100
+    # Fresh Lamb Series 200
+    # Fresh Veal and Calf Series 300
+    # Fresh Pork Series 400
+    # Cured, Cured and Smoked, and Fully Cooked Pork Products Series 500
+    # Cured, Dried, and Smoked Beef Products Series 600
+    # Variety Meats and By-Products Series 700
+    # Sausage Products Series 800
+    # Fresh Goat Series 11
+
+IMPS_MEAT_SERIES = {
+    "1": ("Fresh Beef Series", "beef"),
+    "2": ("Fresh Lamb Series", "lamb"),
+    "3": ("Fresh Veal and Calf Series", "veal"),
+    "4": ("Fresh Pork Series", "pork"),
+    "5": ("Cured, Cured and Smoked, and Fully Cooked Pork Products Series", "pork"),
+    "6": ("Cured, Dried, and Smoked Beef Products Series", "beef"),
+    "7": ("Variety Meats and By-Products Series", "variety meats and meat by-products"), 
+    "8": ("Sausage Products Series", "sauage"),
+    "11": ("Fresh Goat Series", "goat")
+}
+
+# -----------------------------------------------------
+# ---- Regular Expressions constants ----
+# -----------------------------------------------------
+
+# matches any digits
+DIGIT_PATTERN = re.compile(r'(\d+)')
+
+# Matches strings with the URMIS/IMPS string patterns
+URMIS_PATTERN = re.compile(r'URMIS\s*#\s*(?:\d*)', re.IGNORECASE)
+IMPS_PATTERN  = re.compile(r'(IMPS.*(?:\d*))', re.IGNORECASE)

--- a/preprocessing/process_branded.py
+++ b/preprocessing/process_branded.py
@@ -1,3 +1,4 @@
+
 import pandas as pd
 import gc
 from preprocessing._utils import *
@@ -17,6 +18,7 @@ def process_branded(
     # Find the directory containing the downloaded files to define branded_dir
     for path in os.listdir(raw_dir):
         if 'branded' in path:
+            print(f"Found branded data in: {path}")
             branded_dir = os.path.join(raw_dir, path)
             source = define_source(branded_dir)[0]
 
@@ -28,13 +30,17 @@ def process_branded(
     print(f'Initializing processing for:\n> {source}\n')
 
     branded_foods = pd.read_csv(os.path.join(branded_dir, 'branded_food.csv'),
-                                usecols    = ['fdc_id', 'brand_owner', 'brand_name', 'ingredients', 'serving_size', 'serving_size_unit', 'household_serving_fulltext', 'branded_food_category'], 
-                                dtype      = {'fdc_id': 'int32', 'brand_owner': 'str', 'brand_name': 'str', 'ingredients': 'str', 'serving_size': 'float32', 'serving_size_unit': 'str', 'household_serving_fulltext': 'str', 'branded_food_category': 'str'},
+                                usecols    = ['fdc_id', 'brand_owner', 'brand_name', 'ingredients', 'serving_size', 
+                                            'serving_size_unit', 'household_serving_fulltext', 'branded_food_category'], 
+                                dtype      = {'fdc_id': 'int32', 'brand_owner': 'str', 'brand_name': 'str', 'ingredients': 'str', 
+                                            'serving_size': 'float32', 'serving_size_unit': 'str', 'household_serving_fulltext': 'str', 
+                                            'branded_food_category': 'str'},
                                 low_memory = False)
 
     food_nutrients = pd.read_csv(os.path.join(branded_dir, 'food_nutrient.csv'), 
                                 usecols    = ['fdc_id', 'nutrient_id', 'amount'], 
-                                dtype      = {'fdc_id': 'int32', 'nutrient_id': 'int32', 'amount': 'float32'},  
+                                # dtype      = {'fdc_id': 'int32', 'nutrient_id': 'int32', 'amount': 'float32'},  
+                                dtype      = {'fdc_id': 'int32', 'nutrient_id': 'int16', 'amount': 'float32'},   # NOTE Looks like we can just use int16 for this 'nutrient_id'
                                 low_memory = False)
 
     foods = pd.read_csv(os.path.join(branded_dir, 'food.csv'), 
@@ -44,20 +50,31 @@ def process_branded(
 
     nutrients = pd.read_csv(os.path.join(branded_dir, 'nutrient.csv'), 
                                 usecols    = ['id', 'name', 'unit_name'], 
-                                dtype      = {'id': 'int32', 'name': 'str', 'unit_name': 'str'}, 
+                                # dtype      = {'id': 'int32', 'name': 'str', 'unit_name': 'str'}, 
+                                dtype      = {'id': 'int16', 'name': 'str', 'unit_name': 'str'},  # NOTE Looks like we can just use int16 for this 'id'
                                 low_memory = False)
 
-    branded_foods.rename(columns={'serving_size': 'portion_amount', 'serving_size_unit': 'portion_unit', 'household_serving_fulltext': 'portion_modifier', 'branded_food_category': 'category'}, inplace=True)
+    branded_foods.rename(columns={'serving_size': 'portion_amount', 
+                                  'serving_size_unit': 'portion_unit', 
+                                  'household_serving_fulltext': 'portion_modifier', 
+                                  'branded_food_category': 'category'}, inplace=True)
     food_nutrients.rename(columns={'amount': 'nutrient_amount'}, inplace=True)
     foods.rename(columns={'description': 'food_description'}, inplace=True)
     nutrients.rename(columns={'id': 'nutrient_id', 'name': 'nutrient_name', 'unit_name': 'nutrient_unit'}, inplace=True)
 
     gc.collect()
+    
+    # Set data types for all columns, and fill NA values using fillna_and_set_dtypes function
+    branded_foods  = fillna_and_set_dtypes(branded_foods)
+    food_nutrients = fillna_and_set_dtypes(food_nutrients)
+    foods          = fillna_and_set_dtypes(foods)
 
-    # Set data types for all columns, and fill NA values using fillna_and_define_dtype function
-    for df in [branded_foods, food_nutrients, foods, nutrients]:
-        for col in df.columns.tolist():
-            fillna_and_define_dtype(df, col)
+    # NOTE: Old method, checking if the above new method (fillna_and_set_dtypes) doesn't break anything
+    # # Set data types for all columns, and fill NA values using fillna_and_define_dtype function
+    # for df in [branded_foods, food_nutrients, foods, nutrients]:
+    #     # print("Processing data types and filling NA values...")
+    #     for col in df.columns.tolist():
+    #         fillna_and_define_dtype(df, col)
 
     # Join datasets  
     full_foods = pd.merge(food_nutrients, nutrients, on='nutrient_id', how='left')
@@ -79,23 +96,48 @@ def process_branded(
     gc.collect()
 
     # Aggregate rows with equal values and pivot data
-    full_foods = full_foods.groupby(['food_description', 'nutrient_name', 'portion_amount', 'portion_unit']).first()
+    ##############################################################################################################
+    # NOTE: New method for aggregating rows with equal values and pivoting data
+    # foods_subset = full_foods[full_foods['food_description'].str.contains("SWANSON", case=True)]
 
-    full_foods['brand_name'].fillna('no_value', inplace=True)
-    full_foods['portion_modifier'].fillna('no_value', inplace=True)
+    # Stash the first row of each group to join back with the pivoted nutrition data later
+    stashed_food_info = full_foods.groupby(['fdc_id', 'food_description', 'category']).first().reset_index()
+
+    stashed_food_info['brand_name'].fillna('no_value', inplace=True)
+    stashed_food_info['portion_modifier'].fillna('no_value', inplace=True)
 
     full_foods = full_foods.pivot_table(
-                                index=['fdc_id', 
-                                    'food_description', 
-                                    'category', 
-                                    'brand_owner', 
-                                    'brand_name', 
-                                    'ingredients', 
-                                    'portion_amount', 
-                                    'portion_unit',
-                                    'portion_modifier'],
-                                columns='nutrient_name', 
-                                values='per_gram_amt').reset_index()
+                    index=['fdc_id'],
+                    columns='nutrient_name', 
+                    values='per_gram_amt').reset_index()
+    
+    full_foods = pd.merge(stashed_food_info, full_foods, on='fdc_id', how='left')
+    
+    ##############################################################################################################
+    # NOTE: Old method for aggregating rows with equal values and pivoting data
+
+    # full_foods = full_foods.groupby(['food_description', 'nutrient_name', 'portion_amount', 'portion_unit']).first()
+    
+    # full_foods['brand_name'].fillna('no_value', inplace=True)
+    # full_foods['portion_modifier'].fillna('no_value', inplace=True)
+    # # full_foods['brand_name'].fillna(pd.NA, inplace=True)
+    # # full_foods['portion_modifier'].fillna(pd.NA, inplace=True)
+    # full_foods.columns
+    # len(full_foods.fdc_id.unique())
+
+    # full_foods = full_foods.pivot_table(
+    #                             index=['fdc_id', 
+    #                                 'food_description', 
+    #                                 'category', 
+    #                                 'brand_owner', 
+    #                                 'brand_name', 
+    #                                 'ingredients', 
+    #                                 'portion_amount', 
+    #                                 'portion_unit',
+    #                                 'portion_modifier'],
+    #                             columns='nutrient_name', 
+    #                             values='per_gram_amt').reset_index()
+    ##############################################################################################################
 
     gc.collect()
 
@@ -104,13 +146,28 @@ def process_branded(
 
     # Add source columns
     full_foods['usda_data_source'] = define_source(branded_dir)[0]
-    full_foods['data_type'] = define_source(branded_dir)[1]
+    full_foods['data_type']        = define_source(branded_dir)[1]
 
     # Add columns applying ingredient_slicer function
     full_foods['portion_combined'] = full_foods.loc[:, 'portion_amount'].astype(str) + ' ' + full_foods.loc[:, 'portion_unit'] + ' ' + full_foods.loc[:, 'portion_modifier']
-    full_foods['std_portion_amount'] = full_foods['portion_combined'].apply(lambda x: list(apply_ingredient_slicer(x).values())[0])
-    full_foods['std_portion_unit'] = full_foods['portion_combined'].apply(lambda x: list(apply_ingredient_slicer(x).values())[1])
-    full_foods.drop(['portion_combined'], axis=1, inplace=True)
+
+    # TODO: NEW
+    # TODO: New method for extracting ingredients from portion_combined column
+    full_foods['parsed_ingredient']  = full_foods['portion_combined'].apply(lambda x: ingredient_slicer.IngredientSlicer(x).parsed_ingredient()) 
+    # full_foods['parsed_ingredient']  = full_foods['portion_combined'].apply(lambda x: ingredient_slicer.IngredientSlicer(x).to_json())
+    # full_foods['std_portion_amount'] = full_foods['parsed_ingredient'].apply(lambda x: x["quantity"] if x["quantity"] else pd.NA)
+    # full_foods['std_portion_unit']   = full_foods['parsed_ingredient'].apply(lambda x: x["standardized_unit"] if x["standardized_unit"] else pd.NA)
+    full_foods['std_portion_amount'] = full_foods['parsed_ingredient'].apply(lambda x: x["quantity"] if x["quantity"] else "no_value")
+    full_foods['std_portion_unit']   = full_foods['parsed_ingredient'].apply(lambda x: x["standardized_unit"] if x["standardized_unit"] else "no_value")
+    full_foods.drop(['portion_combined', 'parsed_ingredient'], axis=1, inplace=True)
+
+    # # TODO: OLD
+    # # TODO: Old method of doing the ingredient slicer, makes the slicer run twice 
+    # # TODO: instead we can run the IngredientSlicer once and extract the desired values
+    # full_foods['std_portion_amount'] = full_foods['portion_combined'].apply(lambda x: list(apply_ingredient_slicer(x).values())[0])
+    # full_foods['std_portion_unit'] = full_foods['portion_combined'].apply(lambda x: list(apply_ingredient_slicer(x).values())[1])
+    # full_foods.drop(['portion_combined'], axis=1, inplace=True)
+
     gc.collect()
 
     # Format the column names using the format_col_names function
@@ -141,3 +198,151 @@ def process_branded(
             os.removedirs(branded_dir)
         except OSError:
             shutil.rmtree(branded_dir)
+
+#---------------------------------------------------------------------
+# ---- OLD VERSION OF process_branded FUNCTION ----
+# ---------------------------------------------------------------------
+
+# import pandas as pd
+# import gc
+# from preprocessing._utils import *
+
+# def process_branded(
+#         url = None, 
+#         output_dir = None, 
+#         raw_dir = None, 
+#         keep_files = False, 
+#     ):
+
+#     if not os.path.exists(raw_dir):
+#         os.makedirs(raw_dir)
+
+#     download_usda_csv(url, raw_dir)
+
+#     # Find the directory containing the downloaded files to define branded_dir
+#     for path in os.listdir(raw_dir):
+#         if 'branded' in path:
+#             branded_dir = os.path.join(raw_dir, path)
+#             source = define_source(branded_dir)[0]
+
+#     # Delete unnecessary files if keep_files flag is not specified
+#     if not keep_files:
+#         files_to_keep = ['branded_food.csv', 'food_nutrient.csv', 'food.csv', 'nutrient.csv']
+#         delete_unnecessary_files(branded_dir, files_to_keep)
+
+#     print(f'Initializing processing for:\n> {source}\n')
+
+#     branded_foods = pd.read_csv(os.path.join(branded_dir, 'branded_food.csv'),
+#                                 usecols    = ['fdc_id', 'brand_owner', 'brand_name', 'ingredients', 'serving_size', 'serving_size_unit', 'household_serving_fulltext', 'branded_food_category'], 
+#                                 dtype      = {'fdc_id': 'int32', 'brand_owner': 'str', 'brand_name': 'str', 'ingredients': 'str', 'serving_size': 'float32', 'serving_size_unit': 'str', 'household_serving_fulltext': 'str', 'branded_food_category': 'str'},
+#                                 low_memory = False)
+
+#     food_nutrients = pd.read_csv(os.path.join(branded_dir, 'food_nutrient.csv'), 
+#                                 usecols    = ['fdc_id', 'nutrient_id', 'amount'], 
+#                                 dtype      = {'fdc_id': 'int32', 'nutrient_id': 'int32', 'amount': 'float32'},  
+#                                 low_memory = False)
+
+#     foods = pd.read_csv(os.path.join(branded_dir, 'food.csv'), 
+#                                 usecols    = ['fdc_id', 'description'], 
+#                                 dtype      = {'fdc_id': 'int32', 'description': 'str'}, 
+#                                 low_memory = False)
+
+#     nutrients = pd.read_csv(os.path.join(branded_dir, 'nutrient.csv'), 
+#                                 usecols    = ['id', 'name', 'unit_name'], 
+#                                 dtype      = {'id': 'int32', 'name': 'str', 'unit_name': 'str'}, 
+#                                 low_memory = False)
+
+#     branded_foods.rename(columns={'serving_size': 'portion_amount', 'serving_size_unit': 'portion_unit', 'household_serving_fulltext': 'portion_modifier', 'branded_food_category': 'category'}, inplace=True)
+#     food_nutrients.rename(columns={'amount': 'nutrient_amount'}, inplace=True)
+#     foods.rename(columns={'description': 'food_description'}, inplace=True)
+#     nutrients.rename(columns={'id': 'nutrient_id', 'name': 'nutrient_name', 'unit_name': 'nutrient_unit'}, inplace=True)
+
+#     gc.collect()
+
+#     # Set data types for all columns, and fill NA values using fillna_and_define_dtype function
+#     for df in [branded_foods, food_nutrients, foods, nutrients]:
+#         for col in df.columns.tolist():
+#             fillna_and_define_dtype(df, col)
+
+#     # Join datasets  
+#     full_foods = pd.merge(food_nutrients, nutrients, on='nutrient_id', how='left')
+#     full_foods.drop(['nutrient_id'], axis=1, inplace=True)
+    
+#     full_foods = pd.merge(foods, full_foods, on='fdc_id', how='left')
+#     full_foods = pd.merge(full_foods, branded_foods, on='fdc_id', how='left')
+
+#     gc.collect()
+
+#     # Filter for rows with relevant_nutrients using filter_relevent_nutrients function
+#     filter_relevent_nutrients(full_foods)
+
+#     # Add new column for per gram amount using add_per_gram_amt function
+#     add_per_gram_amt(full_foods)
+#     full_foods.drop(['nutrient_unit'], axis=1, inplace=True)
+#     full_foods.drop(['nutrient_amount'], axis=1, inplace=True)
+
+#     gc.collect()
+
+#     # Aggregate rows with equal values and pivot data
+#     full_foods = full_foods.groupby(['food_description', 'nutrient_name', 'portion_amount', 'portion_unit']).first()
+
+#     full_foods['brand_name'].fillna('no_value', inplace=True)
+#     full_foods['portion_modifier'].fillna('no_value', inplace=True)
+
+#     full_foods = full_foods.pivot_table(
+#                                 index=['fdc_id', 
+#                                     'food_description', 
+#                                     'category', 
+#                                     'brand_owner', 
+#                                     'brand_name', 
+#                                     'ingredients', 
+#                                     'portion_amount', 
+#                                     'portion_unit',
+#                                     'portion_modifier'],
+#                                 columns='nutrient_name', 
+#                                 values='per_gram_amt').reset_index()
+
+#     gc.collect()
+
+#     # Add portion_energy column as calorie estimate
+#     full_foods['portion_energy'] = full_foods['Energy'] * full_foods['portion_amount']
+
+#     # Add source columns
+#     full_foods['usda_data_source'] = define_source(branded_dir)[0]
+#     full_foods['data_type'] = define_source(branded_dir)[1]
+
+#     # Add columns applying ingredient_slicer function
+#     full_foods['portion_combined'] = full_foods.loc[:, 'portion_amount'].astype(str) + ' ' + full_foods.loc[:, 'portion_unit'] + ' ' + full_foods.loc[:, 'portion_modifier']
+#     full_foods['std_portion_amount'] = full_foods['portion_combined'].apply(lambda x: list(apply_ingredient_slicer(x).values())[0])
+#     full_foods['std_portion_unit'] = full_foods['portion_combined'].apply(lambda x: list(apply_ingredient_slicer(x).values())[1])
+#     full_foods.drop(['portion_combined'], axis=1, inplace=True)
+#     gc.collect()
+
+#     # Format the column names using the format_col_names function
+#     lst_col_names = full_foods.columns.to_list()
+#     lst_col_names = format_col_names(lst_col_names)
+#     full_foods.columns = lst_col_names
+
+#     # Format the food_description, category, brand_name, and brand_owner values using the format_col_values function
+#     for col in ['food_description', 'category', 'brand_name', 'brand_owner']:
+#         full_foods[col] = full_foods[col].str.replace(',', '').replace('(', '').replace(')', '').str.lower()
+    
+#     # Format ingredient values using the format_ingredients function
+#     full_foods['ingredients'] = full_foods['ingredients'].apply(lambda x: format_ingredients(x))
+
+#     # Save intermediary dataframe
+#     full_foods.to_parquet(os.path.join(output_dir, f'processed_branded.parquet'))
+
+#     # Delete ramining files if keep_files flag is not specified
+#     if not keep_files:
+#         import shutil
+
+#         for root, dirs, files in os.walk(branded_dir):
+#             for file in files:
+#                 file_path = os.path.join(root, file)
+#                 os.remove(file_path)
+
+#         try:
+#             os.removedirs(branded_dir)
+#         except OSError:
+#             shutil.rmtree(branded_dir)

--- a/preprocessing/process_foundation.py
+++ b/preprocessing/process_foundation.py
@@ -65,7 +65,16 @@ def process_foundation(
                                 usecols    = ['id', 'name'], 
                                 dtype      = {'id': 'int32', 'name': 'str'}, 
                                 low_memory=False)
-
+    
+    food_attribute = pd.read_csv(os.path.join(foundation_dir, 'food_attribute.csv'),
+                                usecols    = ["fdc_id", "name", "value"], 
+                                dtype      = {'fdc_id': 'int32', 'name': 'str', 'value': 'str'}, 
+                                low_memory=False)
+    # food_attribute_type = pd.read_csv(os.path.join(foundation_dir, 'food_attribute_type.csv'),
+    #                             # usecols    = ['id', 'name'], 
+    #                             # dtype      = {'id': 'int32', 'name': 'str'}, 
+    #                             low_memory=False)
+    
     food_nutrients.rename(columns={'amount': 'nutrient_amount'}, inplace=True)
     foods.rename(columns={'description': 'food_description', 'food_category_id': 'category_id'}, inplace=True)
     nutrients.rename(columns={'id': 'nutrient_id', 'name': 'nutrient_name', 'unit_name': 'nutrient_unit'}, inplace=True)
@@ -73,13 +82,44 @@ def process_foundation(
     portions.rename(columns={'id': 'portion_id', 'amount': 'portion_amount', 'modifier': 'portion_modifier', 'gram_weight': 'portion_gram_weight'}, inplace=True)
     measure_units.rename(columns={'id': 'measure_unit_id', 'name': 'portion_unit'}, inplace=True)
 
+    food_attribute.rename(columns={'name': 'attribute_name', 'value': 'attribute_value'}, inplace=True)
+
+    ########################################################################### 
+    # Food attribute stuff
+
+    # Filter to just the relevant columns
+    food_attribute = food_attribute[food_attribute['attribute_name'].isin(["Ontology Name for Source", "FoodOn Ontology Name for FDC Item"])]
+
+    # set the long row value names to something shorter and more descriptive
+    food_attribute['attribute_name'][food_attribute['attribute_name'] == "Ontology Name for Source"]          = "food_common_category"
+    food_attribute['attribute_name'][food_attribute['attribute_name'] == "FoodOn Ontology Name for FDC Item"] = "food_common_name"
+
+    # group by the fdc_id and attribute_name and slice off the head of each group
+    food_attribute = food_attribute.groupby(['fdc_id', 'attribute_name']).first().reset_index()  # 2 ways to skin a cat (i.e. get the first value of each group)
+    # food_attribute = food_attribute.groupby(['fdc_id', 'attribute_name']).head(1)
+
+    # pivot the table to have the two values in the same row
+    food_attribute = food_attribute.pivot(index='fdc_id', 
+                                          columns='attribute_name', 
+                                          values='attribute_value').reset_index()
+
+    ####################################################################
+
     gc.collect()
 
-    # Set data types for all columns, and fill NA values using fillna_and_define_dtype function
-    for df in [food_nutrients, foods, nutrients, categories, portions, measure_units]:
-        for col in df.columns.tolist():
-            fillna_and_define_dtype(df, col)
+    # Set data types for all columns, and fill NA values using fillna_and_set_dtypes function
+    food_nutrients     = fillna_and_set_dtypes(food_nutrients)
+    foods              = fillna_and_set_dtypes(foods)
+    nutrients          = fillna_and_set_dtypes(nutrients)
+    categories         = fillna_and_set_dtypes(categories)
+    portions           = fillna_and_set_dtypes(portions)
+    measure_units      = fillna_and_set_dtypes(measure_units)
 
+    # # Set data types for all columns, and fill NA values using fillna_and_define_dtype function
+    # for df in [food_nutrients, foods, nutrients, categories, portions, measure_units]:
+    #     for col in df.columns.tolist():
+    #         fillna_and_define_dtype(df, col)
+    
     # Join datasets
     foods = pd.merge(foods, categories, on='category_id', how='left')
     foods.drop(['category_id'], axis=1, inplace=True)
@@ -90,13 +130,15 @@ def process_foundation(
     # If True, portion_units are non-applicable
     if (portions['measure_unit_id'] == 9999).all():
         portions['portion_unit'] = 'no_value'
+        # portions['portion_unit'] = pd.NA
     else:
         portions = pd.merge(portions, measure_units, on='measure_unit_id', how='left')
 
     portions.drop(['measure_unit_id'], axis=1, inplace=True)
     portions.drop(['portion_id'], axis=1, inplace=True)
-
+    
     full_foods = pd.merge(foods, nutrients, on='fdc_id', how='left')
+    full_foods = pd.merge(full_foods, food_attribute, on='fdc_id', how='left')
     full_foods = pd.merge(full_foods, portions, on='fdc_id', how='inner')
 
     gc.collect()
@@ -108,6 +150,11 @@ def process_foundation(
     add_per_gram_amt(full_foods)
 
     gc.collect()
+
+    # TODO: need to double check this checks out and makes sense
+    # get just the unique food descriptions and common names and stash them to join back after aggregating
+    common_names = full_foods[['food_description', 'food_common_name', 'food_common_category']]
+    common_names = common_names.drop_duplicates(inplace=False)
 
     # Aggregate rows with equal values and pivot data
     full_foods = full_foods.groupby(['food_description', 'category', 'nutrient_name', 'nutrient_unit', 'portion_modifier', 'portion_unit']).mean(numeric_only=True).reset_index()
@@ -122,6 +169,10 @@ def process_foundation(
                                         'portion_gram_weight'],
                                     columns=['nutrient_name'],
                                     values='per_gram_amt').reset_index()
+    
+    # TODO: This is where the common names are joined back
+    # join back the common names
+    full_foods = pd.merge(full_foods, common_names, on='food_description', how='left')
 
     gc.collect()
 
@@ -134,9 +185,21 @@ def process_foundation(
 
     # Add columns applying ingredient_slicer function
     full_foods['portion_combined'] = full_foods.loc[:, 'portion_amount'].astype(str) + ' ' + full_foods.loc[:, 'portion_unit'] + ' ' + full_foods.loc[:, 'portion_modifier']
-    full_foods['std_portion_amount'] = full_foods['portion_combined'].apply(lambda x: list(apply_ingredient_slicer(x).values())[0])
-    full_foods['std_portion_unit'] = full_foods['portion_combined'].apply(lambda x: list(apply_ingredient_slicer(x).values())[1])
-    full_foods.drop(['portion_combined'], axis=1, inplace=True)
+
+    # TODO: NEW
+    # TODO: New method for extracting ingredients from portion_combined column
+    full_foods['parsed_ingredient']  = full_foods['portion_combined'].apply(lambda x: ingredient_slicer.IngredientSlicer(x).parsed_ingredient()) 
+    # full_foods['parsed_ingredient']  = full_foods['portion_combined'].apply(lambda x: ingredient_slicer.IngredientSlicer(x).to_json())
+    # full_foods['std_portion_amount'] = full_foods['parsed_ingredient'].apply(lambda x: x["quantity"] if x["quantity"] else pd.NA)
+    # full_foods['std_portion_unit']   = full_foods['parsed_ingredient'].apply(lambda x: x["standardized_unit"] if x["standardized_unit"] else pd.NA)
+    full_foods['std_portion_amount'] = full_foods['parsed_ingredient'].apply(lambda x: x["quantity"] if x["quantity"] else "no_value")
+    full_foods['std_portion_unit']   = full_foods['parsed_ingredient'].apply(lambda x: x["standardized_unit"] if x["standardized_unit"] else "no_value")
+    full_foods.drop(['portion_combined', 'parsed_ingredient'], axis=1, inplace=True)
+
+    # full_foods['std_portion_amount'] = full_foods['portion_combined'].apply(lambda x: list(apply_ingredient_slicer(x).values())[0])
+    # full_foods['std_portion_unit'] = full_foods['portion_combined'].apply(lambda x: list(apply_ingredient_slicer(x).values())[1])
+    # full_foods.drop(['portion_combined'], axis=1, inplace=True)
+
     gc.collect()
 
     # Format the column names using the format_col_names function
@@ -148,6 +211,25 @@ def process_foundation(
     for col in ['food_description', 'category']:
         full_foods[col] = full_foods[col].str.replace(',', '').replace('(', '').replace(')', '').str.lower()
 
+    # group by food_description and bfill() and ffill() the "food_common_name" column 
+    full_foods['food_common_name'] = np.where(
+                                            full_foods['food_common_name'] == 'no_value',
+                                            np.nan,
+                                            full_foods['food_common_name']
+                                            )
+    full_foods['food_common_name'] = full_foods.groupby('food_description')['food_common_name'].bfill().ffill()
+
+    # group by food_description and bfill() and ffill() the "food_common_category" column 
+    full_foods['food_common_category'] = np.where(
+                                            full_foods['food_common_category'] == 'no_value',
+                                            np.nan,
+                                            full_foods['food_common_category']
+                                            )
+    full_foods['food_common_category'] = full_foods.groupby('food_description')['food_common_category'].bfill().ffill()
+    
+    # Fill in any remaining NaN values with 'no_value'
+    full_foods['food_common_name'].fillna('no_value', inplace=True)
+    full_foods['food_common_category'].fillna('no_value', inplace=True)
 
     # Save intermediary dataframe
     full_foods.to_parquet(os.path.join(output_dir, f'processed_foundation.parquet'))
@@ -175,3 +257,185 @@ def process_foundation(
             os.removedirs(foundation_dir)
         except OSError:
             shutil.rmtree(foundation_dir)
+            
+#---------------------------------------------------------------------
+# ---- OLD VERSION OF process_foundation FUNCTION ----
+# ---------------------------------------------------------------------
+                 
+# import os
+# import pandas as pd
+# import gc
+# from preprocessing._utils import *
+
+# def process_foundation(
+#         urls = None, 
+#         output_dir = None, 
+#         raw_dir = None, 
+#         keep_files = False, 
+#     ):
+
+#     if not os.path.exists(raw_dir):
+#         os.makedirs(raw_dir)
+
+#     for url in urls:
+#         download_usda_csv(url, raw_dir)
+
+#     # Find the directory containing the downloaded files to define foundation_dir
+#     for path in os.listdir(raw_dir):
+#         if 'foundation' in path:
+#             foundation_dir = os.path.join(raw_dir, path)
+#             source = define_source(foundation_dir)[0]
+#         if 'FoodData_Central_csv' in path:
+#             all_dir = os.path.join(raw_dir, path)
+
+#     # Delete unnecessary files if keep_files flag is not specified
+#     if not keep_files:
+#         files_to_keep = ['food_nutrient.csv', 'food.csv', 'nutrient.csv', 'food_portion.csv', 'measure_unit.csv']
+#         delete_unnecessary_files(foundation_dir, files_to_keep)
+
+#         files_to_keep = ['food_category.csv']
+#         delete_unnecessary_files(all_dir, files_to_keep)
+
+#     print(f'Initializing processing for:\n> {source}\n')
+
+#     # Load datasets
+
+#     food_nutrients = pd.read_csv(os.path.join(foundation_dir, 'food_nutrient.csv'), 
+#                                 usecols    = ['fdc_id', 'nutrient_id', 'amount'], 
+#                                 dtype      = {'fdc_id': 'int32', 'nutrient_id': 'int32', 'amount': 'float32'}, 
+#                                 low_memory = False)
+
+#     foods = pd.read_csv(os.path.join(foundation_dir, 'food.csv'),
+#                                 usecols    = ['fdc_id', 'description', 'food_category_id'], 
+#                                 dtype      = {'fdc_id': 'int32', 'description': 'str', 'food_category_id': 'float32'}, 
+#                                 low_memory = False)
+
+#     nutrients = pd.read_csv(os.path.join(foundation_dir, 'nutrient.csv'),
+#                                 usecols    = ['id', 'name', 'unit_name'], 
+#                                 dtype      = {'id': 'int32', 'name': 'str', 'unit_name': 'str'}, 
+#                                 low_memory = False)
+
+#     categories = pd.read_csv(os.path.join(all_dir, 'food_category.csv'),
+#                                 usecols    = ['id', 'description'], 
+#                                 dtype      = {'id': 'int32', 'description': 'str'}, 
+#                                 low_memory = False)
+
+#     portions = pd.read_csv(os.path.join(foundation_dir, 'food_portion.csv'),
+#                                 usecols    = ['id', 'fdc_id', 'amount', 'measure_unit_id', 'modifier', 'gram_weight'], 
+#                                 dtype      = {'id': 'int32', 'fdc_id': 'int32', 'amount': 'float32', 'measure_unit_id': 'int32', 'modifier': 'str', 'gram_weight': 'float32'}, 
+#                                 low_memory = False)
+
+#     measure_units = pd.read_csv(os.path.join(foundation_dir, 'measure_unit.csv'),
+#                                 usecols    = ['id', 'name'], 
+#                                 dtype      = {'id': 'int32', 'name': 'str'}, 
+#                                 low_memory=False)
+
+#     food_nutrients.rename(columns={'amount': 'nutrient_amount'}, inplace=True)
+#     foods.rename(columns={'description': 'food_description', 'food_category_id': 'category_id'}, inplace=True)
+#     nutrients.rename(columns={'id': 'nutrient_id', 'name': 'nutrient_name', 'unit_name': 'nutrient_unit'}, inplace=True)
+#     categories.rename(columns={'id': 'category_id', 'description': 'category'}, inplace=True)
+#     portions.rename(columns={'id': 'portion_id', 'amount': 'portion_amount', 'modifier': 'portion_modifier', 'gram_weight': 'portion_gram_weight'}, inplace=True)
+#     measure_units.rename(columns={'id': 'measure_unit_id', 'name': 'portion_unit'}, inplace=True)
+
+#     gc.collect()
+
+#     # Set data types for all columns, and fill NA values using fillna_and_define_dtype function
+#     for df in [food_nutrients, foods, nutrients, categories, portions, measure_units]:
+#         for col in df.columns.tolist():
+#             fillna_and_define_dtype(df, col)
+
+#     # Join datasets
+#     foods = pd.merge(foods, categories, on='category_id', how='left')
+#     foods.drop(['category_id'], axis=1, inplace=True)
+
+#     nutrients = pd.merge(food_nutrients, nutrients, on='nutrient_id', how='left')
+#     nutrients.drop(['nutrient_id'], axis=1, inplace=True)
+
+#     # If True, portion_units are non-applicable
+#     if (portions['measure_unit_id'] == 9999).all():
+#         portions['portion_unit'] = 'no_value'
+#     else:
+#         portions = pd.merge(portions, measure_units, on='measure_unit_id', how='left')
+
+#     portions.drop(['measure_unit_id'], axis=1, inplace=True)
+#     portions.drop(['portion_id'], axis=1, inplace=True)
+
+#     full_foods = pd.merge(foods, nutrients, on='fdc_id', how='left')
+#     full_foods = pd.merge(full_foods, portions, on='fdc_id', how='inner')
+
+#     gc.collect()
+
+#     # Filter for rows with relevant_nutrients using filter_relevent_nutrients function
+#     filter_relevent_nutrients(full_foods)
+
+#     # Add new column for per gram amount using add_per_gram_amt function
+#     add_per_gram_amt(full_foods)
+
+#     gc.collect()
+
+#     # Aggregate rows with equal values and pivot data
+#     full_foods = full_foods.groupby(['food_description', 'category', 'nutrient_name', 'nutrient_unit', 'portion_modifier', 'portion_unit']).mean(numeric_only=True).reset_index()
+
+#     full_foods = pd.pivot_table(full_foods,
+#                                     index=['fdc_id', 
+#                                         'food_description', 
+#                                         'category', 
+#                                         'portion_amount', 
+#                                         'portion_unit', 
+#                                         'portion_modifier', 
+#                                         'portion_gram_weight'],
+#                                     columns=['nutrient_name'],
+#                                     values='per_gram_amt').reset_index()
+
+#     gc.collect()
+
+#     # Add portion_energy column as calorie estimate
+#     full_foods['portion_energy'] = full_foods['Energy'] * full_foods['portion_gram_weight']
+
+#     # Add source columns
+#     full_foods['usda_data_source'] = define_source(foundation_dir)[0]
+#     full_foods['data_type'] = define_source(foundation_dir)[1]
+
+#     # Add columns applying ingredient_slicer function
+#     full_foods['portion_combined'] = full_foods.loc[:, 'portion_amount'].astype(str) + ' ' + full_foods.loc[:, 'portion_unit'] + ' ' + full_foods.loc[:, 'portion_modifier']
+#     full_foods['std_portion_amount'] = full_foods['portion_combined'].apply(lambda x: list(apply_ingredient_slicer(x).values())[0])
+#     full_foods['std_portion_unit'] = full_foods['portion_combined'].apply(lambda x: list(apply_ingredient_slicer(x).values())[1])
+#     full_foods.drop(['portion_combined'], axis=1, inplace=True)
+#     gc.collect()
+
+#     # Format the column names using the format_col_names function
+#     lst_col_names = full_foods.columns.to_list()
+#     lst_col_names = format_col_names(lst_col_names)
+#     full_foods.columns = lst_col_names
+
+#     # Format the food_description and category values using the format_col_values function
+#     for col in ['food_description', 'category']:
+#         full_foods[col] = full_foods[col].str.replace(',', '').replace('(', '').replace(')', '').str.lower()
+
+
+#     # Save intermediary dataframe
+#     full_foods.to_parquet(os.path.join(output_dir, f'processed_foundation.parquet'))
+
+#     # Delete remaining files if keep_files flag is not specified
+#     if not keep_files:
+#         import shutil
+
+#         for root, dirs, files in os.walk(all_dir):
+#             for file in files:
+#                 file_path = os.path.join(root, file)
+#                 os.remove(file_path)
+
+#         try:
+#             os.removedirs(all_dir)
+#         except OSError:
+#             shutil.rmtree(all_dir)
+
+#         for root, dirs, files in os.walk(foundation_dir):
+#             for file in files:
+#                 file_path = os.path.join(root, file)
+#                 os.remove(file_path)
+
+#         try:
+#             os.removedirs(foundation_dir)
+#         except OSError:
+#             shutil.rmtree(foundation_dir)

--- a/preprocessing/process_srlegacy.py
+++ b/preprocessing/process_srlegacy.py
@@ -1,7 +1,10 @@
 import os
 import pandas as pd
+import numpy as np
 import gc
 from preprocessing._utils import *
+from preprocessing import _constants
+from preprocessing._utils import _find_and_replace_imps_patterns
 
 def process_srlegacy(
         url = None, 
@@ -23,7 +26,9 @@ def process_srlegacy(
 
     # Delete unnecessary files if keep_files flag is not specified
     if not keep_files:
-        files_to_keep = ['food_nutrient.csv', 'food.csv', 'nutrient.csv', 'food_category.csv', 'food_portion.csv', 'measure_unit.csv']
+        files_to_keep = ['food_nutrient.csv', 'food.csv', 'nutrient.csv', 'food_category.csv',
+                          'food_portion.csv','measure_unit.csv',
+                          'food_attribute.csv', 'food_attribute_type.csv']
         delete_unnecessary_files(srlegacy_dir, files_to_keep)
 
     print(f'Initializing processing for:\n> {source}\n')
@@ -58,6 +63,16 @@ def process_srlegacy(
                                 usecols    = ['id', 'name'], 
                                 dtype      = {'id': 'int32', 'name': 'str'}, 
                                 low_memory=False)
+    
+    food_attribute = pd.read_csv(os.path.join(srlegacy_dir, 'food_attribute.csv'),
+                                usecols    = ['fdc_id', 'food_attribute_type_id', 'value'], 
+                                dtype      = {'fdc_id': 'int32', 'food_attribute_type_id': 'int32', 'value': 'str'}, 
+                                low_memory=False)
+    food_attribute_type = pd.read_csv(os.path.join(srlegacy_dir, 'food_attribute_type.csv'),
+                                usecols    = ['id', 'name'], 
+                                dtype      = {'id': 'int32', 'name': 'str'}, 
+                                low_memory=False)
+    
 
     food_nutrients.rename(columns={'amount': 'nutrient_amount'}, inplace=True)
     foods.rename(columns={'description': 'food_description', 'food_category_id': 'category_id'}, inplace=True)
@@ -65,13 +80,27 @@ def process_srlegacy(
     categories.rename(columns={'id': 'category_id', 'description': 'category'}, inplace=True)
     portions.rename(columns={'id': 'portion_id', 'amount': 'portion_amount', 'modifier': 'portion_modifier', 'gram_weight': 'portion_gram_weight'}, inplace=True)
     measure_units.rename(columns={'id': 'measure_unit_id', 'name': 'portion_unit'}, inplace=True)
+    
+    food_attribute.rename(columns = {'name': 'food_attribute_name'}, inplace=True)
+    food_attribute_type.rename(columns = {'id': 'food_attribute_type_id', 'name': 'food_attribute_type'}, inplace=True)
 
     gc.collect()
+    
+    # TODO: inspect this new method for filling NAs and setting datatypes
+    # Set data types for all columns, and fill NA values using fillna_and_set_dtypes function
+    food_nutrients     = fillna_and_set_dtypes(food_nutrients)
+    foods              = fillna_and_set_dtypes(foods)
+    nutrients          = fillna_and_set_dtypes(nutrients)
+    categories         = fillna_and_set_dtypes(categories)
+    portions           = fillna_and_set_dtypes(portions)
+    measure_units      = fillna_and_set_dtypes(measure_units)
+    food_attribute     = fillna_and_set_dtypes(food_attribute)
+    food_attribute_type= fillna_and_set_dtypes(food_attribute_type)
 
-    # Set data types for all columns, and fill NA values using fillna_and_define_dtype function
-    for df in [food_nutrients, foods, nutrients, categories, portions, measure_units]:
-        for col in df.columns.tolist():
-            fillna_and_define_dtype(df, col)
+    # # Set data types for all columns, and fill NA values using fillna_and_define_dtype function
+    # for df in [food_nutrients, foods, nutrients, categories, portions, measure_units, food_attribute, food_attribute_type]:
+    #     for col in df.columns.tolist():
+    #         fillna_and_define_dtype(df, col)
 
     # Join datasets
     foods = pd.merge(foods, categories, on='category_id', how='left')
@@ -80,9 +109,34 @@ def process_srlegacy(
     nutrients = pd.merge(food_nutrients, nutrients, on='nutrient_id', how='left')
     nutrients.drop(['nutrient_id'], axis=1, inplace=True)
 
+    food_attribute = pd.merge(food_attribute, food_attribute_type, on='food_attribute_type_id', how='left')
+    food_attribute.drop(['food_attribute_type_id'], axis=1, inplace=True)
+
+    ###################################################
+
+    # TODO: Code ive added to process IMPS and URMIS strings in the food_attribute table
+    # find and replace the IMPS and URIMIS patterns with "meat" or the appropriate category
+    food_attribute['value'] = food_attribute['value'].str.replace(_constants.URMIS_PATTERN, "meat", regex=True)
+    food_attribute['value'] = food_attribute["value"].apply(lambda x: _find_and_replace_imps_patterns(x))
+    
+    # fill in missing or NaN values with "no_value"
+    # food_attribute['value'] = food_attribute['value'].fillna(pd.NA)
+    food_attribute['value'] = food_attribute['value'].fillna("no_value")
+
+    food_attribute.rename(columns = {'value': 'food_common_name'}, inplace=True)
+    food_attribute.drop(['food_attribute_type'], axis=1, inplace=True)
+
+    # NOTE: could probably be done with np.where() but not gonna take the time
+    # food_attribute["extracted_names"] = np.where(
+    # food_attribute['value'].str.contains("URMIS"), food_attribute['value'].str.extract(URMIS_PATTERN),
+    #  np.where(food_attribute['value'].str.contains("IMPS"), food_attribute['value'].str.extract(IMPS_PATTERN),food_attribute['value']))
+    
+    ########################################################
+
     # If True, portion_units are non-applicable
     if (portions['measure_unit_id'] == 9999).all():
         portions['portion_unit'] = 'no_value'
+        # portions['portion_unit'] = pd.NA
     else:
         portions = pd.merge(portions, measure_units, on='measure_unit_id', how='left')
 
@@ -90,6 +144,7 @@ def process_srlegacy(
     portions.drop(['portion_id'], axis=1, inplace=True)
 
     full_foods = pd.merge(foods, nutrients, on='fdc_id', how='left')
+    full_foods = pd.merge(full_foods, food_attribute, on='fdc_id', how='left')
     full_foods = pd.merge(full_foods, portions, on='fdc_id', how='inner')
 
     gc.collect()
@@ -102,19 +157,32 @@ def process_srlegacy(
 
     gc.collect()
 
+    # TODO: need to double check this checks out and makes sense
+    # get just the unique food descriptions and common names and stash them to join back after aggregating
+    common_names = full_foods[['food_description', 'food_common_name']]
+    common_names = common_names.drop_duplicates(inplace=False)
+
+    # full_foods.columns
     # Aggregate rows with equal values and pivot data
-    full_foods = full_foods.groupby(['food_description', 'category', 'nutrient_name', 'nutrient_unit', 'portion_modifier', 'portion_unit']).mean(numeric_only=True).reset_index()
+    full_foods = full_foods.groupby(['food_description', 'category', 
+                                    #  'food_common_name',
+                                     'nutrient_name', 'nutrient_unit', 'portion_modifier', 'portion_unit']).mean(numeric_only=True).reset_index()
 
     full_foods = pd.pivot_table(full_foods,
                                     index=['fdc_id', 
                                         'food_description', 
                                         'category', 
+                                        # 'food_common_name',
                                         'portion_amount', 
                                         'portion_unit', 
                                         'portion_modifier', 
                                         'portion_gram_weight'],
                                     columns=['nutrient_name'],
                                     values='per_gram_amt').reset_index()
+    
+    # TODO: this is the part where we bring the food_common_name column back in
+    # merge back the common names by the food description column
+    full_foods = pd.merge(full_foods, common_names, on='food_description', how='left')
 
     gc.collect()
 
@@ -127,19 +195,41 @@ def process_srlegacy(
 
     # Add columns applying ingredient_slicer function
     full_foods['portion_combined'] = full_foods.loc[:, 'portion_amount'].astype(str) + ' ' + full_foods.loc[:, 'portion_unit'] + ' ' + full_foods.loc[:, 'portion_modifier']
-    full_foods['std_portion_amount'] = full_foods['portion_combined'].apply(lambda x: list(apply_ingredient_slicer(x).values())[0])
-    full_foods['std_portion_unit'] = full_foods['portion_combined'].apply(lambda x: list(apply_ingredient_slicer(x).values())[1])
-    full_foods.drop(['portion_combined'], axis=1, inplace=True)
+
+    # TODO: NEW
+    # TODO: New method for extracting ingredients from portion_combined column
+    full_foods['parsed_ingredient']  = full_foods['portion_combined'].apply(lambda x: ingredient_slicer.IngredientSlicer(x).parsed_ingredient()) 
+    # full_foods['parsed_ingredient']  = full_foods['portion_combined'].apply(lambda x: ingredient_slicer.IngredientSlicer(x).to_json())
+    # full_foods['std_portion_amount'] = full_foods['parsed_ingredient'].apply(lambda x: x["quantity"] if x["quantity"] else pd.NA)
+    # full_foods['std_portion_unit']   = full_foods['parsed_ingredient'].apply(lambda x: x["standardized_unit"] if x["standardized_unit"] else pd.NA)
+    full_foods['std_portion_amount'] = full_foods['parsed_ingredient'].apply(lambda x: x["quantity"] if x["quantity"] else "no_value")
+    full_foods['std_portion_unit']   = full_foods['parsed_ingredient'].apply(lambda x: x["standardized_unit"] if x["standardized_unit"] else "no_value")
+    full_foods.drop(['portion_combined', 'parsed_ingredient'], axis=1, inplace=True)
+    
+    # full_foods['std_portion_amount'] = full_foods['portion_combined'].apply(lambda x: list(apply_ingredient_slicer(x).values())[0])
+    # full_foods['std_portion_unit'] = full_foods['portion_combined'].apply(lambda x: list(apply_ingredient_slicer(x).values())[1])
+    # full_foods.drop(['portion_combined'], axis=1, inplace=True)
     gc.collect()
 
     # Format the column names using the format_col_names function
-    lst_col_names = full_foods.columns.to_list()
-    lst_col_names = format_col_names(lst_col_names)
+    lst_col_names      = full_foods.columns.to_list()
+    lst_col_names      = format_col_names(lst_col_names)
     full_foods.columns = lst_col_names
 
     # Format the food_description and category values using the format_col_values function
     for col in ['food_description', 'category']:
         full_foods[col] = full_foods[col].str.replace(',', '').replace('(', '').replace(')', '').str.lower()
+
+    # group by food_description and bfill() and ffill() the "food_common_name" column 
+    full_foods['food_common_name'] = np.where(
+                                            full_foods['food_common_name'] == 'no_value',
+                                            np.nan,
+                                            full_foods['food_common_name']
+                                            )
+    full_foods['food_common_name'] = full_foods.groupby('food_description')['food_common_name'].bfill().ffill()
+    
+    # Fill in any remaining NaN values with 'no_value' 
+    full_foods['food_common_name'].fillna('no_value', inplace=True)
 
     # Save intermediary dataframe
     full_foods.to_parquet(os.path.join(output_dir, f'processed_srlegacy.parquet'))
@@ -157,3 +247,168 @@ def process_srlegacy(
             os.removedirs(srlegacy_dir)
         except OSError:
             shutil.rmtree(srlegacy_dir)
+
+#---------------------------------------------------------------------
+# ---- OLD VERSION OF process_srlegacy FUNCTION ----
+# ---------------------------------------------------------------------
+
+# import os
+# import pandas as pd
+# import gc
+# from preprocessing._utils import *
+# from preprocessing._constants import *
+
+# def process_srlegacy(
+#         url = None, 
+#         output_dir = None, 
+#         raw_dir = None, 
+#         keep_files = False, 
+#     ):
+
+#     if not os.path.exists(raw_dir):
+#         os.makedirs(raw_dir)
+
+#     download_usda_csv(url, raw_dir)
+
+#     # Find the directory containing the downloaded files to define srlegacy_dir
+#     for path in os.listdir(raw_dir):
+#         if 'sr_legacy' in path:
+#             srlegacy_dir = os.path.join(raw_dir, path)
+#             source = define_source(srlegacy_dir)[0]
+
+#     # Delete unnecessary files if keep_files flag is not specified
+#     if not keep_files:
+#         files_to_keep = ['food_nutrient.csv', 'food.csv', 'nutrient.csv', 'food_category.csv', 'food_portion.csv', 'measure_unit.csv']
+#         delete_unnecessary_files(srlegacy_dir, files_to_keep)
+
+#     print(f'Initializing processing for:\n> {source}\n')
+
+#     # Load datasets
+#     food_nutrients = pd.read_csv(os.path.join(srlegacy_dir, 'food_nutrient.csv'), 
+#                                 usecols    = ['fdc_id', 'nutrient_id', 'amount'], 
+#                                 dtype      = {'fdc_id': 'int32', 'nutrient_id': 'int32', 'amount': 'float32'}, 
+#                                 low_memory = False)
+
+#     foods = pd.read_csv(os.path.join(srlegacy_dir, 'food.csv'), 
+#                                 usecols    = ['fdc_id', 'description', 'food_category_id'], 
+#                                 dtype      = {'fdc_id': 'int32', 'description': 'str', 'food_category_id': 'float32'}, 
+#                                 low_memory = False)
+
+#     nutrients = pd.read_csv(os.path.join(srlegacy_dir, 'nutrient.csv'),
+#                                 usecols    = ['id', 'name', 'unit_name'], 
+#                                 dtype      = {'id': 'int32', 'name': 'str', 'unit_name': 'str'}, 
+#                                 low_memory = False)
+
+#     categories = pd.read_csv(os.path.join(srlegacy_dir, 'food_category.csv'), 
+#                                 usecols    = ['id', 'description'], 
+#                                 dtype      = {'id': 'int32', 'description': 'str'}, 
+#                                 low_memory = False)
+
+#     portions = pd.read_csv(os.path.join(srlegacy_dir, 'food_portion.csv'), 
+#                                 usecols    = ['id', 'fdc_id', 'amount', 'measure_unit_id', 'modifier', 'gram_weight'], 
+#                                 dtype      = {'id': 'int32', 'fdc_id': 'int32', 'amount': 'float32', 'measure_unit_id': 'int32', 'modifier': 'str', 'gram_weight': 'float32'}, 
+#                                 low_memory = False)
+
+#     measure_units = pd.read_csv(os.path.join(srlegacy_dir, 'measure_unit.csv'),
+#                                 usecols    = ['id', 'name'], 
+#                                 dtype      = {'id': 'int32', 'name': 'str'}, 
+#                                 low_memory=False)
+
+#     food_nutrients.rename(columns={'amount': 'nutrient_amount'}, inplace=True)
+#     foods.rename(columns={'description': 'food_description', 'food_category_id': 'category_id'}, inplace=True)
+#     nutrients.rename(columns={'id': 'nutrient_id', 'name': 'nutrient_name', 'unit_name': 'nutrient_unit'}, inplace=True)
+#     categories.rename(columns={'id': 'category_id', 'description': 'category'}, inplace=True)
+#     portions.rename(columns={'id': 'portion_id', 'amount': 'portion_amount', 'modifier': 'portion_modifier', 'gram_weight': 'portion_gram_weight'}, inplace=True)
+#     measure_units.rename(columns={'id': 'measure_unit_id', 'name': 'portion_unit'}, inplace=True)
+
+#     gc.collect()
+
+#     # Set data types for all columns, and fill NA values using fillna_and_define_dtype function
+#     for df in [food_nutrients, foods, nutrients, categories, portions, measure_units]:
+#         for col in df.columns.tolist():
+#             fillna_and_define_dtype(df, col)
+
+#     # Join datasets
+#     foods = pd.merge(foods, categories, on='category_id', how='left')
+#     foods.drop(['category_id'], axis=1, inplace=True)
+
+#     nutrients = pd.merge(food_nutrients, nutrients, on='nutrient_id', how='left')
+#     nutrients.drop(['nutrient_id'], axis=1, inplace=True)
+
+#     # If True, portion_units are non-applicable
+#     if (portions['measure_unit_id'] == 9999).all():
+#         portions['portion_unit'] = 'no_value'
+#     else:
+#         portions = pd.merge(portions, measure_units, on='measure_unit_id', how='left')
+
+#     portions.drop(['measure_unit_id'], axis=1, inplace=True)
+#     portions.drop(['portion_id'], axis=1, inplace=True)
+
+#     full_foods = pd.merge(foods, nutrients, on='fdc_id', how='left')
+#     full_foods = pd.merge(full_foods, portions, on='fdc_id', how='inner')
+
+#     gc.collect()
+
+#     # Filter for rows with relevant_nutrients using filter_relevent_nutrients function
+#     filter_relevent_nutrients(full_foods)
+
+#     # Add new column for per gram amount using add_per_gram_amt function
+#     add_per_gram_amt(full_foods)
+
+#     gc.collect()
+
+#     # Aggregate rows with equal values and pivot data
+#     full_foods = full_foods.groupby(['food_description', 'category', 'nutrient_name', 'nutrient_unit', 'portion_modifier', 'portion_unit']).mean(numeric_only=True).reset_index()
+
+#     full_foods = pd.pivot_table(full_foods,
+#                                     index=['fdc_id', 
+#                                         'food_description', 
+#                                         'category', 
+#                                         'portion_amount', 
+#                                         'portion_unit', 
+#                                         'portion_modifier', 
+#                                         'portion_gram_weight'],
+#                                     columns=['nutrient_name'],
+#                                     values='per_gram_amt').reset_index()
+
+#     gc.collect()
+
+#     # Add portion_energy column as calorie estimate
+#     full_foods['portion_energy'] = full_foods['Energy'] * full_foods['portion_gram_weight']
+
+#     # Add source columns
+#     full_foods['usda_data_source'] = define_source(srlegacy_dir)[0]
+#     full_foods['data_type'] = define_source(srlegacy_dir)[1]
+
+#     # Add columns applying ingredient_slicer function
+#     full_foods['portion_combined'] = full_foods.loc[:, 'portion_amount'].astype(str) + ' ' + full_foods.loc[:, 'portion_unit'] + ' ' + full_foods.loc[:, 'portion_modifier']
+#     full_foods['std_portion_amount'] = full_foods['portion_combined'].apply(lambda x: list(apply_ingredient_slicer(x).values())[0])
+#     full_foods['std_portion_unit'] = full_foods['portion_combined'].apply(lambda x: list(apply_ingredient_slicer(x).values())[1])
+#     full_foods.drop(['portion_combined'], axis=1, inplace=True)
+#     gc.collect()
+
+#     # Format the column names using the format_col_names function
+#     lst_col_names = full_foods.columns.to_list()
+#     lst_col_names = format_col_names(lst_col_names)
+#     full_foods.columns = lst_col_names
+
+#     # Format the food_description and category values using the format_col_values function
+#     for col in ['food_description', 'category']:
+#         full_foods[col] = full_foods[col].str.replace(',', '').replace('(', '').replace(')', '').str.lower()
+
+#     # Save intermediary dataframe
+#     full_foods.to_parquet(os.path.join(output_dir, f'processed_srlegacy.parquet'))
+
+#     # Delete remaining files if keep_files flag is not specified
+#     if not keep_files:
+#         import shutil
+
+#         for root, dirs, files in os.walk(srlegacy_dir):
+#             for file in files:
+#                 file_path = os.path.join(root, file)
+#                 os.remove(file_path)
+
+#         try:
+#             os.removedirs(srlegacy_dir)
+#         except OSError:
+#             shutil.rmtree(srlegacy_dir)


### PR DESCRIPTION

- added a `_constants.py` file for converting some meat units to human readable food categories
- reduced number of calls to ingredient_slicer,
- added code to keep all `fdc_ids` in the Branded Foods
- added food_attribute data to `foundation foods` and `sr legacy`
- moved all code that is applied to the 3 processed datasets (`stacked_data` DataFrame) into a function in `_utils.py` called `postprocess_stacked_df()`
- Created a revised version of your fill NA function called `fillna_and_set_dtypes()` which actually returns a pandas Dataframe with the NAs filled and proper datatypes set. It also makes use of `pandas.fillna()` functions ability to take in a map of key:value pairs of the form `column: column default value` as a single argument. This cuts down on having to iterate through each column/key in the map and apply `pandas.fillna()` invidivdually on each column.
- Meant to write a couple tests for the workflow and for my edits, but i didnt have the time.... someday